### PR TITLE
Set package ecosystem to 'npm'

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -5,7 +5,7 @@
 
 version: 2
 updates:
-  - package-ecosystem: '' # See documentation for possible values
+  - package-ecosystem: 'npm' # See documentation for possible values
     directory: '/' # Location of package manifests
     schedule:
       interval: 'weekly'


### PR DESCRIPTION
Dependabot fails since we have no package ecosystem set